### PR TITLE
fix(client_secret): Fixed error with client secret

### DIFF
--- a/nodejs/src/shortcode.test.ts
+++ b/nodejs/src/shortcode.test.ts
@@ -17,6 +17,7 @@ describe('shortcode oauth', () => {
     oauth = new OAuthClient(
       {
         clientId: 'clientId',
+        clientSecret: 'clientSecret',
         scopes,
       },
       requester,
@@ -74,6 +75,7 @@ describe('shortcode oauth', () => {
           grant_type: 'refresh_token',
           refresh_token: 'expired_refresh_token',
           client_id: 'clientId',
+          client_secret: 'clientSecret',
         })
         .resolves({
           json: mockTokenResponse,
@@ -97,6 +99,7 @@ describe('shortcode oauth', () => {
       requester.json
         .withArgs('post', 'oauth/token', {
           client_id: 'clientId',
+          client_secret: 'clientSecret',
           grant_type: 'authorization_code',
           code: 'oauth_authorization_code',
         })
@@ -108,7 +111,7 @@ describe('shortcode oauth', () => {
       requester.json
         .withArgs('post', 'oauth/shortcode', {
           client_id: 'clientId',
-          client_secret: undefined,
+          client_secret: 'clientSecret',
           scope: scopes.join(' '),
         })
         .resolves({

--- a/nodejs/src/shortcode.ts
+++ b/nodejs/src/shortcode.ts
@@ -97,6 +97,7 @@ export class OAuthShortCode {
     private readonly scopes: string[],
     private readonly fetcher: IRequester,
     response: IShortcodeCreateResponse,
+    private readonly clientSecret?: string,
   ) {
     this.handle = response.handle;
     this.expiresIn = response.expires_in;
@@ -157,6 +158,7 @@ export class OAuthShortCode {
   private async getTokens({ code }: { code: string }): Promise<OAuthTokens> {
     const res = await this.fetcher.json('post', 'oauth/token', {
       client_id: this.clientId,
+      client_secret: this.clientSecret,
       grant_type: 'authorization_code',
       code,
     });
@@ -238,7 +240,7 @@ export class OAuthClient {
       throw new UnexpectedHttpError(res);
     }
 
-    return new OAuthShortCode(this.options.clientId, this.options.scopes, this.fetcher, res.json);
+    return new OAuthShortCode(this.options.clientId, this.options.scopes, this.fetcher, res.json, this.options.clientSecret);
   }
 
   /**
@@ -249,6 +251,7 @@ export class OAuthClient {
       grant_type: 'refresh_token',
       refresh_token: tokens.data.refreshToken,
       client_id: this.options.clientId,
+      client_secret: this.options.clientSecret,
     });
 
     if (res.statusCode >= 300) {


### PR DESCRIPTION
It seems like there's an error on during the short code OAuth flow when using `clientSecret`:

```
Unexpected status code 400 Bad Request from : {"error":"invalid_client","error_description":"OAuth client secret invalid."}
```

It seems to be in the auth code token exchange step after getting the handle.

This should fix it.  After making these changes locally, I was able to complete the flow.  Unfortunately I was only able to test the JavaScript side and reverse engineer the changes to TypeScript.  

I updated the tests as well.

Let me know if I can help.  I'd love to see this released soon so I can use NPM.

